### PR TITLE
Parse :=

### DIFF
--- a/src/opamDocCmi.ml
+++ b/src/opamDocCmi.ml
@@ -120,7 +120,9 @@ let read_tag res: Documentation.tag -> tag = function
 
 let read_documentation res : Documentation.t -> text * tag list = function
   | Cinfo(txt, tags) -> read_text res txt, List.map (read_tag res) tags
-  | Cstop -> assert false
+  | Cstop ->
+      (* FIXME: need a better story for handling ocamldoc stop comments *)
+      [], []
 
 let rec read_attributes res : Parsetree.attributes -> doc = function
   | ({txt = "doc"}, PDoc(d, _)) :: rest ->

--- a/src/opamDocPath.ml
+++ b/src/opamDocPath.ml
@@ -56,6 +56,24 @@ let check_lident x =
         !ok
     | c -> false
 
+let check_tident x =
+  let len = String.length x in
+  if len = 0 then false
+  else match x.[0] with
+    | '#' -> len > 1 && check_lident (String.sub x 1 (len-1))
+    | 'a' .. 'z' | '_' ->
+        let ok = ref true in
+        for i = 1 to (len - 1) do
+          match x.[i] with
+          | 'A' .. 'Z'
+          | 'a' .. 'z'
+          | '0' .. '9'
+          | '_' | '\'' -> ()
+          | c -> ok := false
+        done;
+        !ok
+    | c -> false
+
 let check_operator x =
   let len = String.length x in
   if len = 0 then None
@@ -81,7 +99,7 @@ module UName = struct
 
   let of_string x =
     if check_uident x then x
-    else failwith ("Invalid name " ^ x)
+    else failwith ("Invalid uppercase name " ^ x)
 
   let to_json x = `String x
 
@@ -111,7 +129,37 @@ module LName = struct
 
   let of_string x =
     if check_lident x then x
-    else failwith ("Invalid name " ^ x)
+    else failwith ("Invalid lowercase name " ^ x)
+
+  let to_json s = `String s
+
+  let compare n1 n2 =
+    match compare (String.lowercase n1) (String.lowercase n2) with
+    | 0 -> compare n1 n2
+    | i -> i
+
+  module O = struct
+    type t = string
+    let compare = compare
+    let to_string = to_string
+    let to_json = to_json
+  end
+
+  module Set = OpamMisc.Set.Make(O)
+
+  module Map = OpamMisc.Map.Make(O)
+
+end
+
+module TName = struct
+
+  type t = string
+
+  let to_string x = x
+
+  let of_string x =
+    if check_tident x then x
+    else failwith ("Invalid type name " ^ x)
 
   let to_json s = `String s
 
@@ -299,7 +347,7 @@ end
 
 module Type = struct
 
-  module Name = LName
+  module Name = TName
 
   type t =
     { parent: Module.t;

--- a/src/opamDocPath.ml
+++ b/src/opamDocPath.ml
@@ -40,8 +40,9 @@ let check_uident x =
 let check_lident x =
   let len = String.length x in
   if len = 0 then false
-  else
-    match x.[0] with
+  else match x with
+    | ":=" -> true
+    | _ -> match x.[0] with
     | 'a' .. 'z' | '_' ->
         let ok = ref true in
         for i = 1 to (len - 1) do


### PR DESCRIPTION
Fix #35

The OCaml parser has a special support for `:=` apparently
