### PR TITLE
Include failing XML file in parse errors

### DIFF
--- a/src/opamDocState.ml
+++ b/src/opamDocState.ml
@@ -81,8 +81,9 @@ let read_xml parser file =
     OpamGlobals.error_and_exit "Missing file %s" (OpamFilename.prettify file);
   let ic = OpamFilename.open_in file in
   try
+    let source = Some (OpamFilename.to_string file) in
     let input = Xmlm.make_input (`Channel ic) in
-    let result = parser input in
+    let result = parser OpamDocXml.({ input; source }) in
     close_in ic;
     result
   with End_of_file | Failure _ ->

--- a/src/opamDocXml.mli
+++ b/src/opamDocXml.mli
@@ -14,21 +14,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+type input = {
+  source : string option;
+  input  : Xmlm.input;
+}
+
 (** Serialize documentation to XML *)
 
 val module_to_xml: Xmlm.output -> OpamDocTypes.module_ -> unit
 
-val module_of_xml: Xmlm.input -> OpamDocTypes.module_
+val module_of_xml: input -> OpamDocTypes.module_
 
 val module_type_to_xml: Xmlm.output -> OpamDocTypes.module_type -> unit
 
-val module_type_of_xml: Xmlm.input -> OpamDocTypes.module_type
+val module_type_of_xml: input -> OpamDocTypes.module_type
 
 val library_to_xml: Xmlm.output -> OpamDocTypes.library -> unit
 
-val library_of_xml: Xmlm.input -> OpamDocTypes.library
+val library_of_xml: input -> OpamDocTypes.library
 
 val package_to_xml: Xmlm.output -> OpamDocTypes.package -> unit
 
-val package_of_xml: Xmlm.input -> OpamDocTypes.package
+val package_of_xml: input -> OpamDocTypes.package
 


### PR DESCRIPTION
Creates a new OpamDocXml.input abstraction to track the Xmlm.input and the optional file source string
