### PR TITLE
Sync with compiler

### DIFF
--- a/src/opamDocCmi.ml
+++ b/src/opamDocCmi.ml
@@ -45,12 +45,6 @@ and read_text_element res : Documentation.text_element -> text = function
   | Code s -> [Code s]
   | PreCode s -> [PreCode s]
   | Verbatim s -> [Verbatim s]
-  | Style(SK_custom s as sty, []) ->
-      if String.length s > 1 && s.[0] = '_' then
-        let s = String.sub s 1 (String.length s - 1) in
-        read_text_element res Documentation.(Style (SK_subscript, [Raw s]))
-      else
-        [Style(read_style sty, [])]
   | Style(sk, txt) -> [Style(read_style sk, read_text res txt)]
   | List l -> [List(List.map (read_text res) l)]
   | Enum l -> [Enum(List.map (read_text res) l)]

--- a/src/opamDocCmi.ml
+++ b/src/opamDocCmi.ml
@@ -55,9 +55,6 @@ and read_text_element res : Documentation.text_element -> text = function
   | List l -> [List(List.map (read_text res) l)]
   | Enum l -> [Enum(List.map (read_text res) l)]
   | Newline -> [Newline]
-  | Block txt ->
-      (* There is actually no way to build a block element with ocamldoc. *)
-      assert false
   | Title(i, l, txt) -> [Title (i, l, read_text res txt)]
   | Ref(RK_module, s, txt) -> begin
       match lookup_module res s, txt with


### PR DESCRIPTION
This removes handling of `Block` and the work-around for the subscript lexing bug. Both these issues are now fixed in the compiler patch.
